### PR TITLE
\include zu \input außerhalb von \begin{Document}

### DIFF
--- a/Arbeit.tex
+++ b/Arbeit.tex
@@ -31,9 +31,9 @@ overfullrule, % entfernen nach abschluss der bearbeitung
 % %BCOR=korrektur, % absoluter Wert der Bindekorrektur
 }
 
-\include{00_Allgemein/Metadaten}
-\include{00_Allgemein/Packages}
-\include{00_Allgemein/Befehle}
+\input{00_Allgemein/Metadaten}
+\input{00_Allgemein/Packages}
+\input{00_Allgemein/Befehle}
 
 % Typesetting options
 \widowpenalty=10000     % Hurenkinder


### PR DESCRIPTION
Da \include nur innerhalb von \begin{document} verwendet werden sollte. Auf \input geändert.